### PR TITLE
Prevents creating fields with a pipe ( | ) in the title

### DIFF
--- a/App_LocalResources/FieldEditor.ascx.resx
+++ b/App_LocalResources/FieldEditor.ascx.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ControlHelpText.Help" xml:space="preserve">
     <value>This is the Help Text displayed to the user to explain this field.</value>
@@ -257,5 +257,8 @@
   </data>
   <data name="ListSettings.Text" xml:space="preserve">
     <value>List Settings</value>
+  </data>
+  <data name="TitleCannotHavePipe.Text" xml:space="preserve">
+    <value>The pipe character is not allowed in the field title.</value>
   </data>
 </root>

--- a/Controls/Field.ascx
+++ b/Controls/Field.ascx
@@ -22,6 +22,17 @@
         <span class="dnnFormMessage dnnFormError" runat="server" Visible="false" id="divError"/>  
         <asp:RequiredFieldValidator  runat="server" ErrorMessage="RequiredFieldValidator" 
                                      ControlToValidate="txtFieldTitle"  resourcekey="TitleIsRequired" CssClass="dnnFormMessage dnnFormError"/>
+        <asp:CustomValidator 
+            ID="valNoPipesInTitle"            
+            runat="server" 
+            ErrorMessage="The title may not contain the pipe ( | ) character" 
+            ControlToValidate="txtFieldTitle" 
+            resourcekey="TitleCannotHavePipe" 
+            CssClass="dnnFormMessage dnnFormError" 
+            OnServerValidate="valNoPipesInTitle_ServerValidate" 
+            ClientValidationFunction="validateNoPipes" 
+            EnableClientScript="true" 
+            />
         
     </div>
     <div class="dnnFormItem" id="panHelpText" runat="server">
@@ -145,5 +156,14 @@
     function OpenHelpWindow(url) {
         window.open(url, '', 'width=800, height=800, location=no, menubar=no, resizable=yes, scrollbars=yes, status=no, toolbar=no');
         window.event.returnValue = false;
+    }
+
+    function validateNoPipes(sender, args) {
+        var text = args.Value;
+        if (text.indexOf('|')>=0) {
+            args.IsValid = false;
+            return;
+        }
+        args.IsValid = true;
     }
 </script>

--- a/Controls/Field.ascx.cs
+++ b/Controls/Field.ascx.cs
@@ -426,5 +426,16 @@ namespace DotNetNuke.Modules.UserDefinedTable.Controls
             panValidationMessage.Visible = selectedType.SupportsValidation;
             panHelpText.Visible = selectedType.SupportsEditing;
         }
+
+        protected void valNoPipesInTitle_ServerValidate(object source, System.Web.UI.WebControls.ServerValidateEventArgs args)
+        {
+            var text = args.Value;
+            if (text.Contains('|'))
+            {
+                args.IsValid = false;
+                return;
+            }
+            args.IsValid = true;
+        }
     }
 }

--- a/Controls/Field.ascx.designer.cs
+++ b/Controls/Field.ascx.designer.cs
@@ -67,6 +67,15 @@ namespace DotNetNuke.Modules.UserDefinedTable.Controls {
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl divError;
         
         /// <summary>
+        /// valNoPipesInTitle control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.CustomValidator valNoPipesInTitle;
+        
+        /// <summary>
         /// panHelpText control.
         /// </summary>
         /// <remarks>

--- a/DotNetNuke.Modules.UserDefinedTable.xml
+++ b/DotNetNuke.Modules.UserDefinedTable.xml
@@ -207,6 +207,15 @@
             To modify move field declaration from designer file to code-behind file.
             </remarks>
         </member>
+        <member name="F:DotNetNuke.Modules.UserDefinedTable.Controls.Field.valNoPipesInTitle">
+            <summary>
+            valNoPipesInTitle control.
+            </summary>
+            <remarks>
+            Auto-generated field.
+            To modify move field declaration from designer file to code-behind file.
+            </remarks>
+        </member>
         <member name="F:DotNetNuke.Modules.UserDefinedTable.Controls.Field.panHelpText">
             <summary>
             panHelpText control.

--- a/releasenotes.htm
+++ b/releasenotes.htm
@@ -5,6 +5,7 @@
     <li>Build process updated to use Nuget packages, module can now be built on vanilla Visual Studio setup even without Dnn present.</li>
     <li>Fixes and issue with the Dnn captcha not showing, adds support (optionnaly) to replace Dnn Captcha by Google ReCatcha.(Issues 21)</li>
     <li>Fixed an issue where it was impossible to apply a template created by one module into another module (Issue 26)</li>
+    <li>Prevents creating fields with a pipe ( | ) in the title, which made the module break (Issue 9)</li>
 </ul>
 
 <h2>DNN Form and List 06.04.00</h2>


### PR DESCRIPTION

Prevents creating fields with a pipe ( | ) in the title which made the module break, closes #9