### PR TITLE
Fixed an issue where the search would not work after clicking on Show Records

### DIFF
--- a/List.ascx.cs
+++ b/List.ascx.cs
@@ -362,6 +362,10 @@ namespace DotNetNuke.Modules.UserDefinedTable
                 else
                 {
                     var @params = new List<string>();
+                    if (_parent.Request.QueryString["show"] == "records")
+                    {
+                        @params.Add("show/records");
+                    }
                     var moduleId = _parent.ModuleId;
                     if (! string.IsNullOrEmpty(TxtSearch.Text))
                     {
@@ -389,7 +393,9 @@ namespace DotNetNuke.Modules.UserDefinedTable
                 }
                 else
                 {
-                    _parent.Response.Redirect(Globals.NavigateURL(_parent.TabId));
+                    string parameters = _parent.Request.QueryString["show"] == "records" ? "show/records" : "";
+                    
+                    _parent.Response.Redirect(Globals.NavigateURL(_parent.TabId, "", parameters));
                 }
             }
         }

--- a/releasenotes.htm
+++ b/releasenotes.htm
@@ -6,6 +6,7 @@
     <li>Fixes and issue with the Dnn captcha not showing, adds support (optionnaly) to replace Dnn Captcha by Google ReCatcha.(Issues 21)</li>
     <li>Fixed an issue where it was impossible to apply a template created by one module into another module (Issue 26)</li>
     <li>Prevents creating fields with a pipe ( | ) in the title, which made the module break (Issue 9)</li>
+    <li>Fixed an issue where the search would not work after clicking on Show Records and clicking Reset Search would redirect the user to the form instead of staying in the list mode (Issue 14)</li>
 </ul>
 
 <h2>DNN Form and List 06.04.00</h2>


### PR DESCRIPTION

Fixed an issue where the search would not work after clicking on Show Records and clicking Reset Search would redirect the user to the form instead of staying in the list mode, closes #14