### PR TITLE
Correction for issue #54

### DIFF
--- a/DataTypes/Date.cs
+++ b/DataTypes/Date.cs
@@ -34,7 +34,7 @@ namespace DotNetNuke.Modules.UserDefinedTable.DataTypes
                 }
                 ctlDate.ID = CleanID(string.Format("{0}_date", FieldTitle));
                 ctlDate.CssClass = "fnl-datepicker";
-                if (Required) ctlDate.CssClass += "dnnFormRequired";
+                if (Required) ctlDate.CssClass += " dnnFormRequired";
 
                 Controls.Add(ctlDate);
                 CtlValueBox = ctlDate;


### PR DESCRIPTION
It was added an additional space to avoid class for required date field rendered as fnl-datepickerdnnFormRequired

correct class value now will be fnl-datepicker dnnFormRequired